### PR TITLE
Adds cc as a dependency regardless of operating system.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ lto = true
 codegen-units = 1
 panic = "abort"
 
+[build-dependencies]
+cc = "1.0"
+
 [target.'cfg(windows)'.build-dependencies]
-cc = "1"
 winres = "0.1"
 
 [dependencies]


### PR DESCRIPTION
When building on Linux, building spits out an error that cc is not a recognized crate. cc is not explicitly defined as a dependency for Linux builds, causing the build.rs script to fail. This change fixes this error.